### PR TITLE
add print to xxx methods

### DIFF
--- a/lib/src/Logger.cpp
+++ b/lib/src/Logger.cpp
@@ -11,6 +11,8 @@
 #include <QDateTime>
 #include <QMutexLocker>
 
+#include <iostream>
+
 /*!
   */
 Logger::Logger()
@@ -268,7 +270,32 @@ Logger::selectCorrectLogLevel(int chosenPriority) const
     return loglevel;
 }
 
-#include <iostream>
+
+/*!
+ * \brief Logger::printToStdOut will enable or disable the printout of logged message to stdout
+ * \param enable the new status of the std::cout printout
+ * \note the printing will \em not take log priority into account so \em every message will be printed to std::cout
+ * The purpose of this function is to cleanup code during debugging and allow programmers see all the messages that might go into log files
+ * directly on console
+ */
+void Logger::printToStdOut(bool enable)
+{ m_printToStdOut = enable; }
+
+
+/*!
+ * \brief Logger::printToQDebug
+ * \param enablethe new status of the qDebug() printout
+ * \note the printing will \em not take log priority into account so \em every message will be printed with qDebug()
+ * The purpose of this function is to cleanup code during debugging and allow programmers see all the messages that might go into log files
+ * directly on console
+ */
+void Logger::printToQDebug(bool enable)
+{ m_printToQDebug = enable; }
+
+/*!
+ * \brief Logger::printAlsoToConsoleIfRequired will print out to std::cout and/or with qDebug() (that is std::cerr but with different timing due to buffering)
+ * \param mess the QString containing the message to print
+ */
 void Logger::printAlsoToConsoleIfRequired(const QString &mess)
 {
     if (m_printToQDebug)

--- a/lib/src/Logger.h
+++ b/lib/src/Logger.h
@@ -28,7 +28,7 @@ class ULOG_LIB_API Logger: public QObject
     Q_OBJECT
 
     int m_logVerbosityAcceptedLevel, m_logVerbosityDefaultLevel;
-
+    bool m_printToStdOut, m_printToQDebug;
     QString m_moduleName, m_errorPrefix, m_timeStampFormat, m_spacingString;
     QMap<QThread*, BufferOfStrings> m_bufferedStreamMessages;
     QChar m_startEncasingChar, m_endEncasingChar;
@@ -48,6 +48,8 @@ class ULOG_LIB_API Logger: public QObject
     //* access ctor and addLogDevice() and removeLogDevice()
     friend class UniqLogger;
 
+    void printAlsoToConsoleIfRequired(const QString &message);
+    
 signals:
     void writersToDelete(const QList<LogWriter*>);
 
@@ -66,6 +68,8 @@ public:
     void setTimeStampFormat         ( const QString&    );
     void setSpacingString           ( const QString &   );
     void setEncasingChars           ( const QChar&, const QChar& );
+    void printToStdOut(bool enable) { m_printToStdOut = enable; }
+    void printToQDebug(bool enable) { m_printToQDebug = enable; }
 
     //GETTERS
     int getVerbosityLevel() const;
@@ -74,12 +78,15 @@ public:
     QString getModuleName() const       { return m_moduleName;      }
     QString getTStampFmtString() const  { return m_timeStampFormat; }
     QString getSpacingString() const    { return m_spacingString;   }
+    bool printToStdOut() const          { return m_printToStdOut;   }
+    bool printToQDebug() const          { return m_printToQDebug;   }
 
     //LOGGING
     void log( int, const char*, ... );
     void log( const char*, ...      );
     void flush();
     void monitor( const QVariant &data, const QString &key, const QString &desc="");
+
 
     Logger& operator<< ( const UNQL::LogMessagePriorityType& d      );
     Logger& operator<< ( const UNQL::LogStreamManipType& d          );

--- a/lib/src/Logger.h
+++ b/lib/src/Logger.h
@@ -68,8 +68,8 @@ public:
     void setTimeStampFormat         ( const QString&    );
     void setSpacingString           ( const QString &   );
     void setEncasingChars           ( const QChar&, const QChar& );
-    void printToStdOut(bool enable) { m_printToStdOut = enable; }
-    void printToQDebug(bool enable) { m_printToQDebug = enable; }
+    void printToStdOut(bool enable);
+    void printToQDebug(bool enable);
 
     //GETTERS
     int getVerbosityLevel() const;

--- a/lib/uniqlogger.pro
+++ b/lib/uniqlogger.pro
@@ -455,6 +455,7 @@ unix {
             message("UNQL normal deploy behaviour enabled on iOS")
             QMAKE_POST_LINK += "cp -aP $$DLL $$FINALDIR $$escape_expand(\\n\\t)"
             QMAKE_POST_LINK += "cp -aP $$DLL $$DSTDIR $$escape_expand(\\n\\t)"
+            QMAKE_POST_LINK += $(RANLIB) $$DSTDIR/libUniqLogger_iOS.a $$escape_expand(\\n\\t)
         }
     } else {
         QMAKE_POST_LINK += "cp -aP $$DLL $$FINALDIR $$escape_expand(\\n\\t)"

--- a/testlogger/testlogger2.cpp
+++ b/testlogger/testlogger2.cpp
@@ -213,8 +213,13 @@ testlogger_cli::timedLog()
 
 #if(TEST_FILE_ROTATION)
     qDebug() << "written " << i * 2 << "KB to file...";
+    qDebug() << "is loggerF1 printing to qdebug()? " << loggerF1->printToQDebug();
+    loggerF1->printToQDebug(false);
+    qDebug() << "is loggerF2 printing to qdebug()? " << loggerF2->printToStdOut();
+    loggerF2->printToStdOut(true);
     loggerF1->log(UNQL::LOG_INFO, ( QString("file text iteration ") + QString::number(i) + " " + QString().fill('a', 1500) ).toLatin1().constData() );
     loggerF2->log(UNQL::LOG_INFO, ( QString("file2 text iteration") + QString::number(i) + " " + QString().fill('b', 500) ).toLatin1().constData() );
+    *loggerF2 << UNQL::LOG_WARNING << "Do you see me?" << UNQL::EOM;
 #endif
 
 


### PR DESCRIPTION
Add to Logger class the methods to print to QDebug and std::cout (qdebug goes to cerr and on iOS is n displayed)
so that we can avoid in code stuff like:

```
...
*logger << UNQL::LOG_INFO << "A message" << UNQL::EOM;
qDebug() << "A message"; //used for debugging in console
*logger << UNQL::LOG_INFO << "Another message" << UNQL::EOM;
qDebug() << "Another message"; //used for debugging in console
...
```

the code could be refactored like:

```
#ifdef DEBUG
logger->printToQDebug(true);
#endif
...
*logger << UNQL::LOG_INFO << "A message" << UNQL::EOM;
*logger << UNQL::LOG_INFO << "Another message" << UNQL::EOM;
...
```